### PR TITLE
Support `Log` bytecodes

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -4,6 +4,7 @@ use evmil::util::w256;
 use crate::analysis::{BytecodeAnalysis,AbstractState};
 use crate::opcodes::OPCODES;
 
+#[derive(Debug)]
 pub enum Bytecode {
     Comment(String),
     Unit(bool,&'static str),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -163,6 +163,9 @@ impl DafnyPrinter {
             Bytecode::Dup(n) => {
                 self.println(&format!("\tst := Dup(st,{n});"));                                     
             }
+            Bytecode::Log(n) => {
+                self.println(&format!("\tst := LogN(st,{n});"));                                     
+            }            
             Bytecode::Jump(targets) => {
                 self.print_jump(targets);
             }
@@ -187,9 +190,6 @@ impl DafnyPrinter {
             }            
             Bytecode::Unit(_,name) => {
                 self.println(&format!("\tst := {name}(st);"));                
-            }
-            _ => {
-                self.println("\t// ???");
             }
         }
     }


### PR DESCRIPTION
These were not being printed previously.