### PR TITLE
Add exclusions for invalid stack sizes

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -90,7 +90,9 @@ impl<T:Write> BlockPrinter<T> {
                 }
                 if min != max { write!(self.out,")"); }
                 writeln!(self.out,"");
-            } 
+            } else if min <= sh && sts.len() == 0 {
+                writeln!(self.out,"\trequires st'.Operands() != {sh}");                
+            }
         }
     }
 


### PR DESCRIPTION
In some cases, we have to exclude possible stack sizes as they are impossible.